### PR TITLE
docs: fix tool inconsistencies, stale refs, add burndown charts

### DIFF
--- a/docs/agile.md
+++ b/docs/agile.md
@@ -78,30 +78,14 @@ The backlog contained **15 user stories** — deliberately more than could fit i
 
 ### Burn-Down Chart
 
-```
-Story days remaining
-15 |  *
-   |
-13 |  .  *
-   |
- 7 |        *
-   |
- 3 |              *
-   |
- 0 |                    *
-   +----+----+----+----+----
-     4w   3w   2w   1w   0w
-     left left left left left
-
-* = actual remaining work
-```
+![Iteration 1 Burndown Chart](https://quickchart.io/chart?w=600&h=300&c=%7B%22type%22%3A%20%22line%22%2C%20%22data%22%3A%20%7B%22labels%22%3A%20%5B%22Sprint%20Start%22%2C%20%22Week%202%22%2C%20%22Week%203%22%2C%20%22Sprint%20End%22%5D%2C%20%22datasets%22%3A%20%5B%7B%22label%22%3A%20%22Actual%22%2C%20%22data%22%3A%20%5B13%2C%207%2C%203%2C%200%5D%2C%20%22fill%22%3A%20false%2C%20%22borderColor%22%3A%20%22rgb%28220%2C38%2C38%29%22%2C%20%22backgroundColor%22%3A%20%22rgb%28220%2C38%2C38%29%22%2C%20%22tension%22%3A%200.1%7D%2C%20%7B%22label%22%3A%20%22Ideal%22%2C%20%22data%22%3A%20%5B13%2C%206.5%2C%203.25%2C%200%5D%2C%20%22fill%22%3A%20false%2C%20%22borderColor%22%3A%20%22rgb%28156%2C163%2C175%29%22%2C%20%22borderDash%22%3A%20%5B6%2C%204%5D%2C%20%22tension%22%3A%200%7D%5D%7D%2C%20%22options%22%3A%20%7B%22title%22%3A%20%7B%22display%22%3A%20true%2C%20%22text%22%3A%20%22Iteration%201%20%E2%80%94%20Burndown%20Chart%22%7D%2C%20%22scales%22%3A%20%7B%22yAxes%22%3A%20%5B%7B%22ticks%22%3A%20%7B%22beginAtZero%22%3A%20true%2C%20%22suggestedMax%22%3A%2015%7D%2C%20%22scaleLabel%22%3A%20%7B%22display%22%3A%20true%2C%20%22labelString%22%3A%20%22Story%20Days%20Remaining%22%7D%7D%5D%2C%20%22xAxes%22%3A%20%5B%7B%22scaleLabel%22%3A%20%7B%22display%22%3A%20true%2C%20%22labelString%22%3A%20%22Week%22%7D%7D%5D%7D%7D%7D)
 
 | Checkpoint | Days Remaining |
 |------------|---------------|
-| 4 weeks left | 13 days |
-| 2 weeks left | 7 days |
-| 1 week left | 3 days |
-| 0 weeks left | 0 days |
+| Sprint Start (4 weeks left) | 13 days |
+| Week 2 (2 weeks left) | 7 days |
+| Week 3 (1 week left) | 3 days |
+| Sprint End | 0 days |
 
 ### Results
 
@@ -163,28 +147,14 @@ Story days remaining
 
 ### Burn-Down Chart
 
-```
-Story days remaining
-15 |  *
-   |     \
-10 |      *
-   |         \
- 4 |           *
-   |              \
- 0 |               *
-   +----+----+----+----+----
-     4w   3w   2w   1w   0w
-     left left left left left
-
-* = actual remaining work
-```
+![Iteration 2 Burndown Chart](https://quickchart.io/chart?w=600&h=300&c=%7B%22type%22%3A%20%22line%22%2C%20%22data%22%3A%20%7B%22labels%22%3A%20%5B%22Sprint%20Start%22%2C%20%22Week%202%22%2C%20%22Week%203%22%2C%20%22Sprint%20End%22%5D%2C%20%22datasets%22%3A%20%5B%7B%22label%22%3A%20%22Actual%22%2C%20%22data%22%3A%20%5B15%2C%2010%2C%204%2C%200%5D%2C%20%22fill%22%3A%20false%2C%20%22borderColor%22%3A%20%22rgb%28220%2C38%2C38%29%22%2C%20%22backgroundColor%22%3A%20%22rgb%28220%2C38%2C38%29%22%2C%20%22tension%22%3A%200.1%7D%2C%20%7B%22label%22%3A%20%22Ideal%22%2C%20%22data%22%3A%20%5B15%2C%207.5%2C%203.75%2C%200%5D%2C%20%22fill%22%3A%20false%2C%20%22borderColor%22%3A%20%22rgb%28156%2C163%2C175%29%22%2C%20%22borderDash%22%3A%20%5B6%2C%204%5D%2C%20%22tension%22%3A%200%7D%5D%7D%2C%20%22options%22%3A%20%7B%22title%22%3A%20%7B%22display%22%3A%20true%2C%20%22text%22%3A%20%22Iteration%202%20%E2%80%94%20Burndown%20Chart%22%7D%2C%20%22scales%22%3A%20%7B%22yAxes%22%3A%20%5B%7B%22ticks%22%3A%20%7B%22beginAtZero%22%3A%20true%2C%20%22suggestedMax%22%3A%2016%7D%2C%20%22scaleLabel%22%3A%20%7B%22display%22%3A%20true%2C%20%22labelString%22%3A%20%22Story%20Days%20Remaining%22%7D%7D%5D%2C%20%22xAxes%22%3A%20%5B%7B%22scaleLabel%22%3A%20%7B%22display%22%3A%20true%2C%20%22labelString%22%3A%20%22Week%22%7D%7D%5D%7D%7D%7D)
 
 | Checkpoint | Days Remaining |
 |------------|---------------|
-| 4 weeks left | 15 days |
-| 2 weeks left | 10 days |
-| 1 week left | 4 days |
-| 0 weeks left | 0 days |
+| Sprint Start (4 weeks left) | 15 days |
+| Week 2 (2 weeks left) | 10 days |
+| Week 3 (1 week left) | 4 days |
+| Sprint End | 0 days |
 
 ### Results
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -23,7 +23,7 @@ This page documents the architectural, database, and user interface design decis
 
 FeedMe follows a **decoupled client–server architecture**. The frontend and backend are separate applications that communicate via a REST API. This separation allows each layer to be developed, tested, and deployed independently.
 
-> 🔗 **[View interactive architecture diagram on Miro](https://miro.com/welcomeonboard/WHl5QUhjeHdEVFcrRjdxY1FYcW9tNEF2dGc2eHIyZ3VIWlcvcFNYdHROR2FtVVpYUklQWXJVNTZlRUhSeWdJY280blBSakY0T09RRHNhUlJyUVlrWWNTVmxHWmh3UkJkcTM2bTBtY2R2SXRwcG4wbEV3Tm9wVlhiUU1wUXZ1d3RzVXVvMm53MW9OWFg1bkJoVXZxdFhRPT0hdjE=?share_link_id=390991071424)** — includes full system architecture, component relationships and navigation flow.
+> 🔗 **[View interactive architecture diagram on Miro](https://miro.com/welcomeonboard/WHl5QUhjeHdEVFcrRjdxY1FYcW9tNEF2dGc2eHIyZ3VIWlcvcFNYdHROR2FtVVpYUklQWXJVNTZlRUhSeWdJY280blBSakY0T09RRHNhUlJyUVlrWWNTVmxHWmh3UkJkcTM2bTBtY2R2SXRWcEVBRzVDSEdOOEdjZURRM3RxZE9zVXVvMm53MW9OWFg5bkJoVXZxdFhRPT0hdjE=?share_link_id=675059761588)** — includes full system architecture, component relationships and navigation flow.
 
 ```mermaid
 graph TB
@@ -63,7 +63,7 @@ graph TB
 
 The database schema was designed using an entity-relationship approach and documented with an interactive diagram.
 
-> 🔗 **[View full ER diagram on Miro](https://miro.com/welcomeonboard/WHl5QUhjeHdEVFcrRjdxY1FYcW9tNEF2dGc2eHIyZ3VIWlcvcFNYdHROR2FtVVpYUklQWXJVNTZlRUhSeWdJY280blBSakY0T09RRHNhUlJyUVlrWWNTVmxHWmh3UkJkcTM2bTBtY2R2SXRwcG4wbEV3Tm9wVlhiUU1wUXZ1d3RzVXVvMm53MW9OWFg1bkJoVXZxdFhRPT0hdjE=?share_link_id=390991071424)**
+> 🔗 **[View full ER diagram on Miro](https://miro.com/welcomeonboard/WHl5QUhjeHdEVFcrRjdxY1FYcW9tNEF2dGc2eHIyZ3VIWlcvcFNYdHROR2FtVVpYUklQWXJVNTZlRUhSeWdJY280blBSakY0T09RRHNhUlJyUVlrWWNTVmxHWmh3UkJkcTM2bTBtY2R2SXRWcEVBRzVDSEdOOEdjZURRM3RxZE9zVXVvMm53MW9OWFg5bkJoVXZxdFhRPT0hdjE=?share_link_id=675059761588)**
 
 The database models reflect the core domain of a food delivery application: users place orders from restaurants, each order containing menu items.
 
@@ -217,7 +217,7 @@ Wireframe mockups were created during iteration planning using **[NinjaMock](htt
 
 The full mockup collection is also available on our interactive Miro board:
 
-> 🔗 **[View full interactive Miro board](https://miro.com/welcomeonboard/WHl5QUhjeHdEVFcrRjdxY1FYcW9tNEF2dGc2eHIyZ3VIWlcvcFNYdHROR2FtVVpYUklQWXJVNTZlRUhSeWdJY280blBSakY0T09RRHNhUlJyUVlrWWNTVmxHWmh3UkJkcTM2bTBtY2R2SXRwcG4wbEV3Tm9wVlhiUU1wUXZ1d3RzVXVvMm53MW9OWFg1bkJoVXZxdFhRPT0hdjE=?share_link_id=390991071424)** — includes all wireframe screens, colour palette, and navigation flow.
+> 🔗 **[View full interactive Miro board](https://miro.com/welcomeonboard/WHl5QUhjeHdEVFcrRjdxY1FYcW9tNEF2dGc2eHIyZ3VIWlcvcFNYdHROR2FtVVpYUklQWXJVNTZlRUhSeWdJY280blBSakY0T09RRHNhUlJyUVlrWWNTVmxHWmh3UkJkcTM2bTBtY2R2SXRWcEVBRzVDSEdOOEdjZURRM3RxZE9zVXVvMm53MW9OWFg5bkJoVXZxdFhRPT0hdjE=?share_link_id=675059761588)** — includes all wireframe screens, colour palette, and navigation flow.
 
 #### Iteration 1 Mockups
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -14,12 +14,12 @@ This page documents the features delivered in each iteration, the technology sta
 
 [**Open FeedMe App**](https://main.d29mzie0h3ms32.amplifyapp.com){: .btn .btn-primary .fs-5 .mb-4 }
 
-The frontend is deployed on Vercel and publicly accessible. The app demonstrates the complete Iteration 1 user journey: browse food categories, manage the shopping cart, proceed through checkout, and view the order confirmation.
+The frontend is deployed on **AWS Amplify** and publicly accessible. The app demonstrates the complete two-iteration user journey: account creation, browsing restaurants, managing the shopping cart, checkout, order tracking, order history, delivery location management, and account settings.
 
 | Environment | URL | Status |
 |-------------|-----|--------|
-| Production (frontend) | [feedme-dusky.vercel.app](https://main.d29mzie0h3ms32.amplifyapp.com) | Live |
-| Backend API | Django / local dev | Available via `python manage.py runserver` |
+| Production (frontend) | [main.d29mzie0h3ms32.amplifyapp.com](https://main.d29mzie0h3ms32.amplifyapp.com) | Live |
+| Backend API | Django / AWS Elastic Beanstalk | Available via `python manage.py runserver` (local) |
 
 <details open markdown="block">
   <summary>Table of contents</summary>

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -149,13 +149,15 @@ This page documents all tools used during the development of FeedMe, explaining 
 
 ---
 
-### draw.io / diagrams.net (Architecture Diagrams)
+### Miro (Architecture & UML Diagrams)
 
-**What:** Free online diagramming tool.
+**What:** Online collaborative whiteboard and diagramming platform.
 
-**Why:** draw.io is browser-based (no install required), exports to SVG/PNG, and integrates with VS Code via extension. It was used to sketch the initial system architecture before coding began.
+**Why:** Miro is browser-based, supports real-time multi-user editing, and allows the creation of UML-style architecture diagrams and component relationship maps. It was used to produce and share the system architecture diagram and navigation flow for FeedMe.
 
-**Used for:** Architecture diagram drafts, component relationship sketches
+**Used for:** System architecture diagram, component relationships, navigation flow
+
+**Link:** [View FeedMe Architecture on Miro](https://miro.com/welcomeonboard/WHl5QUhjeHdEVFcrRjdxY1FYcW9tNEF2dGc2eHIyZ3VIWlcvcFNYdHROR2FtVVpYUklQWXJVNTZlRUhSeWdJY280blBSakY0T09RRHNhUlJyUVlrWWNTVmxHWmh3UkJkcTM2bTBtY2R2SXRWcEVBRzVDSEdOOEdjZURRM3RxZE9zVXVvMm53MW9OWFg5bkJoVXZxdFhRPT0hdjE=?share_link_id=675059761588)
 
 ---
 
@@ -169,13 +171,13 @@ This page documents all tools used during the development of FeedMe, explaining 
 
 ---
 
-### Figma (UI Wireframes)
+### NinjaMock (UI Wireframes)
 
-**What:** Browser-based UI design and wireframing tool.
+**What:** Browser-based wireframe and UI prototyping tool.
 
-**Why:** Figma allows multiple team members to collaborate on wireframes in real time. Mockup screens were created in Figma before implementation to agree on layout and user flow, reducing rework during coding.
+**Why:** NinjaMock is purpose-built for rapid wireframing of mobile and web interfaces. It was used to create one mockup screen per user story before implementation began, aligning the team on expected layout and user flow before any code was written.
 
-**Used for:** UI wireframes for all 15 user stories (image exports stored in `/images`)
+**Used for:** UI wireframes for all 15 user stories — one mockup per user story (image exports stored in `/images` and `/frontend/public/images`)
 
 ---
 
@@ -207,9 +209,9 @@ This page documents all tools used during the development of FeedMe, explaining 
 | Version control | Git + GitHub | - | Source control, collaboration |
 | Package manager (JS) | npm | 10.x | JS dependencies |
 | Package manager (Python) | pip + venv | - | Python dependencies |
-| Diagrams | draw.io | Online | Architecture diagrams |
+| Diagrams | Miro | Online | Architecture & UML diagrams |
 | DB design | dbdiagram.io | Online | ER diagrams |
-| UI mockups | Figma | Online | Wireframes |
+| UI mockups | NinjaMock | Online | Wireframes |
 | Project management | GitHub Projects | - | Kanban board |
 | AI assistance | Claude / ChatGPT | - | Scaffolding, docs |
 

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -21,9 +21,9 @@ FeedMe uses **Git** and **GitHub** for all version control. This page documents 
 
 The project is hosted on GitHub at:
 
-[https://github.com/leonardrein/cp3407-project](https://github.com/leonardrein/cp3407-project)
+[https://github.com/William-Bowman-JCU/cp3407-project](https://github.com/William-Bowman-JCU/cp3407-project)
 
-The repository was forked from the course template (`jc138691/cp3407-project-v2024`) and extended with full source code, documentation, and project management artefacts.
+The repository was forked from the course template (`jc138691/cp3407-project-v2024`) and extended with full source code, documentation, and project management artefacts. The project was developed collaboratively by all four team members committing to this shared repository.
 
 ---
 
@@ -81,12 +81,14 @@ GitHub Issues are used to track user stories and bugs in Iteration 2. All open i
 
 | Issue | Title | Labels | Status |
 |-------|-------|--------|--------|
-| #6 | Account Settings | `iteration-2`, `user-story` | Open |
-| #9 | Restaurant menu configuration | `iteration-2`, `user-story` | Open |
-| #10 | UI Designs for User Stories 09–15 | `iteration-2`, `user-story` | Open |
+| #6 | Account Settings | `iteration-2`, `user-story` | ✅ Closed |
+| #9 | Restaurant menu configuration | `iteration-2`, `user-story` | ✅ Closed |
+| #10 | UI Designs for User Stories 09–15 | `iteration-2`, `user-story` | ✅ Closed |
+
+All Iteration 2 issues were resolved and closed at the end of the iteration (April 2026).
 
 Issues can be viewed at:
-[https://github.com/leonardrein/cp3407-project/issues](https://github.com/leonardrein/cp3407-project/issues)
+[https://github.com/William-Bowman-JCU/cp3407-project/issues](https://github.com/William-Bowman-JCU/cp3407-project/issues)
 
 ---
 
@@ -115,9 +117,9 @@ All 7 iteration 1 user stories were moved to **Done**:
 - Checkout (Payment & Confirmation)
 - Track Order
 
-### Iteration 2 — Current Board State
+### Iteration 2 — Board State at Completion
 
-Iteration 2 stories are in the **In Progress** column as the team works toward the April 10 deadline.
+All 7 delivered Iteration 2 user stories were moved to **Done**. US-15 (Filter Restaurants) was correctly deferred as the lowest-priority story when velocity capacity was reached.
 
 ---
 
@@ -140,6 +142,6 @@ This ensures only source code and documentation are tracked, keeping the reposit
 
 GitHub's commit graph and contributor statistics provide full transparency of individual contributions. The instructor can verify each team member's participation via:
 
-- **Commit history**: `https://github.com/leonardrein/cp3407-project/commits/main`
-- **Contributors graph**: `https://github.com/leonardrein/cp3407-project/graphs/contributors`
+- **Commit history**: `https://github.com/William-Bowman-JCU/cp3407-project/commits/main`
+- **Contributors graph**: `https://github.com/William-Bowman-JCU/cp3407-project/graphs/contributors`
 - **Issue comments**: Activity on individual GitHub Issues


### PR DESCRIPTION
## Summary

- **NinjaMock replaces Figma** in `tools.md` — corrects the wireframing tool to match `design.md`
- **Miro added as UML/architecture tool** in `tools.md` with direct shareable link
- **All repo URLs fixed** in `version-control.md`: `leonardrein/` → `William-Bowman-JCU/`
- **Issue statuses updated** in `version-control.md`: all IT2 issues marked ✅ Closed
- **Stale IT2 deadline text removed** — replaced with IT2 completion summary
- **Burndown charts upgraded**: ASCII diagrams replaced with real chart images via quickchart.io
- **Miro link updated** in `design.md` with latest public shareable URL
- **Vercel references removed** from `implementation.md`: replaced with AWS Amplify

## Files Changed

| File | Change |
|------|--------|
| `docs/tools.md` | Figma → NinjaMock; draw.io → Miro with link |
| `docs/design.md` | Miro link updated to latest shareable URL |
| `docs/version-control.md` | All URLs fixed; issues closed; stale deadline text removed |
| `docs/agile.md` | ASCII burndown charts → real chart images (quickchart.io) |
| `docs/implementation.md` | Vercel → AWS Amplify |

## Test Plan

- [ ] GitHub Pages `/agile` — burndown chart images render correctly
- [ ] GitHub Pages `/design` — Miro link opens the board publicly
- [ ] GitHub Pages `/tools` — NinjaMock listed for wireframes, Miro for architecture
- [ ] GitHub Pages `/version-control` — all links point to `William-Bowman-JCU/cp3407-project`, issues show as closed
- [ ] GitHub Pages `/implementation` — no Vercel references remain