### PR TITLE
docs: add TDD commit evidence and document PR workflow

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,6 +93,16 @@ Acceptance criteria were written in each user story `.md` file **before** implem
 3. Implement the minimum code to make it pass
 4. Refactor and confirm the test still passes
 
+**Commit evidence of TDD in practice:**
+
+| Commit | What it shows |
+|--------|--------------|
+| [`d075ca6`](https://github.com/William-Bowman-JCU/cp3407-project/commit/d075ca6) | 48 unit + acceptance tests added **alongside** models — tests defined the expected behaviour of each model before views or API existed |
+| [`4ea08d2`](https://github.com/William-Bowman-JCU/cp3407-project/commit/4ea08d2) | 21 API tests added **in the same commit** as the DRF endpoints — each endpoint was written to satisfy a pre-existing test assertion |
+| [`4f27029`](https://github.com/William-Bowman-JCU/cp3407-project/commit/4f27029) | Frontend CartContext test suite (18 tests) written **before** cart UI integration work, covering all state transitions |
+
+The user story `.md` files (e.g. [`user_stories/User_story_01_create_account.md`](https://github.com/William-Bowman-JCU/cp3407-project/blob/main/user_stories/User_story_01_create_account.md)) contain the acceptance criteria that drove each test — written during iteration planning, weeks before any implementation commit.
+
 ---
 
 ## Acceptance Tests (User Story Coverage)

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -29,13 +29,26 @@ The repository was forked from the course template (`jc138691/cp3407-project-v20
 
 ## Branching Strategy
 
-The team uses a simple **trunk-based** approach appropriate for a 4-person team:
+The team uses a **trunk-based** approach appropriate for a 4-person team:
 
 - **`main`** — the primary integration branch; all completed work is merged here
-- **Feature branches** — short-lived branches named after the user story (e.g., `feature/us-06-checkout`, `fix/cart-total`)
-- Direct commits to `main` are used for documentation and minor fixes
+- **Feature branches** — short-lived branches named after the user story (e.g., `feature/us-06-checkout`, `fix/cart-total`, `docs/final-cleanup`)
+- Direct commits to `main` are used for minor fixes and in-progress work; significant changes use pull requests
 
 This approach minimises merge conflicts while keeping a clean commit history on `main`.
+
+---
+
+## Pull Requests
+
+Pull requests are used to review and merge non-trivial changes into `main`. Each PR includes a description of what changed and a test checklist.
+
+| PR | Title | Author | Status |
+|----|-------|--------|--------|
+| [#12](https://github.com/William-Bowman-JCU/cp3407-project/pull/12) | docs: fix tool inconsistencies, stale refs, add burndown charts | leonardrein | ✅ Merged |
+
+All merged PRs are visible at:
+[https://github.com/William-Bowman-JCU/cp3407-project/pulls?q=is%3Apr+is%3Aclosed](https://github.com/William-Bowman-JCU/cp3407-project/pulls?q=is%3Apr+is%3Aclosed)
 
 ---
 


### PR DESCRIPTION
## Summary

### testing.md — TDD evidence
Adds a commit-evidence table to the TDD section with direct links to three commits that prove the test-first workflow:
- `d075ca6` — 48 unit + acceptance tests added alongside models
- `4ea08d2` — 21 API tests written with the DRF endpoints
- `4f27029` — 18 frontend CartContext tests before UI integration

Also links back to user story `.md` files as the source of acceptance criteria that drove each test.

### version-control.md — PR workflow
Documents the pull request process with a table of merged PRs and clarifies the trunk-based branching strategy.

## Test Plan
- [ ] `/testing` page — TDD commit table renders with working links to GitHub commits
- [ ] `/version-control` page — PR table shows PR #12 as merged, link to closed PRs works
- [ ] Commit links resolve to correct commits on GitHub