### PR TITLE
docs: simplify team page — remove individual contribution lists

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -8,75 +8,19 @@ nav_order: 9
 
 FeedMe was developed by a team of four on-campus students enrolled in CP3407 Advanced Software Engineering at James Cook University (2026).
 
-<details open markdown="block">
-  <summary>Table of contents</summary>
-  {: .text-delta }
-- TOC
-{:toc}
-</details>
-
 ---
 
 ## Team Members
 
-| Name | GitHub | Role |
-|------|--------|------|
-| Leonard Rein | [@leonardrein](https://github.com/leonardrein) | Developer, Project Lead, Documentation |
-| William Bowman | [@William-Bowman-JCU](https://github.com/William-Bowman-JCU) | Developer |
-| Joyal Joy | [@JoeJCU](https://github.com/JoeJCU) | Developer |
-| Joe David Mathew | [@AlanWilson112114](https://github.com/AlanWilson112114) | Developer |
+| Name | GitHub |
+|------|--------|
+| Leonard Rein | [@leonardrein](https://github.com/leonardrein) |
+| William Bowman | [@William-Bowman-JCU](https://github.com/William-Bowman-JCU) |
+| Joyal Joy | [@JoeJCU](https://github.com/JoeJCU) |
+| Joe David Mathew | [@AlanWilson112114](https://github.com/AlanWilson112114) |
 
----
-
-## Individual Contributions
-
-GitHub's commit history and issue activity provide a transparent, timestamped record of each team member's contributions. The contributor graph is available at:
-
-[https://github.com/leonardrein/cp3407-project/graphs/contributors](https://github.com/leonardrein/cp3407-project/graphs/contributors)
-
-### Leonard Rein
-
-- Led overall project structure and repository setup
-- Implemented shared Navbar component and global layout (`layout.tsx`)
-- Implemented FeedMe home page with food category browsing
-- Implemented Payment & Confirmation feature (US-06/US-07)
-- Applied FeedMe branding — red/black colour scheme, dark background
-- Wrote all 15 user story documentation files
-- Wrote iteration planning documents (Iteration 1 and 2)
-- Set up GitHub Pages documentation (this site)
-- Maintained README, `.gitignore`, and repository structure
-
-### William Bowman
-
-- Development contributions to Iteration 2 features
-- Repository collaboration and code review
-
-### Joyal Joy
-
-- Development contributions across both iterations
-- User story implementation support
-
-### Joe David Mathew
-
-- Development contributions to frontend components
-- UI mockup contributions for user stories 10–15
-
----
-
-## Contribution Evidence
-
-Individual contributions are verifiable through:
-
-1. **Commit timestamps** — every commit is attributed to its author via GitHub's commit log
-2. **Issue activity** — comments and assignments on GitHub Issues show who worked on what
-3. **Kanban board** — card movements on the project board are timestamped per user
-4. **Pull request history** — any PRs submitted show author and review activity
-
----
-
-## Team Feedback Form
-
-Each team member submitted an individual team feedback form to the course coordinator as required by CP3407 assessment guidelines.
+Individual contributions are visible in the commit history and contributor graph:
+[https://github.com/William-Bowman-JCU/cp3407-project/graphs/contributors](https://github.com/William-Bowman-JCU/cp3407-project/graphs/contributors)
 
 ---
 
@@ -87,4 +31,11 @@ The team agreed on the following norms at the start of the project:
 - Communicate blockers via group chat within 24 hours
 - Push working code to `main` at least once per week
 - Review and update the Kanban board before each practical session
-- User stories must meet their acceptance criteria before being marked Done on the board
+- User stories must meet their acceptance criteria before being marked Done
+- All significant changes go through a pull request for visibility
+
+---
+
+## Team Feedback
+
+Each team member submitted an individual team feedback form to the course coordinator as required by CP3407 assessment guidelines.


### PR DESCRIPTION
## What changed

The previous `team.md` listed each person's contributions explicitly — but only Leonard's section had real detail while the other three had vague 2-line entries. This looked imbalanced and self-promotional.

## What it looks like now

- Clean team members table with GitHub links
- Link to contributor graph — individual contributions are verifiable there, not self-reported here
- Working agreement (kept and slightly expanded)
- Team feedback confirmation (kept)

The marker can see who did what from the commit history, which is more credible than a self-written list.